### PR TITLE
Enable http-auth during API-Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ An example file is provided in `/usr/local/etc/letsencrypt/certbot-pdns.json`:
 {
   "api-key": "change_it",
   "base-url": "http://127.0.0.1:34022/api/v1",
-  "axfr-time": 5
+  "axfr-time": 5,
+  "http-auth": ["user", "secret_pass"],
+  "verify-cert": "False"
 }
 ```
 
@@ -48,6 +50,10 @@ Configuration keys:
  - api-key: Your PowerDNS API Key as specified in property `api-key` in file `/etc/powerdns/pdns.conf`
  - base-url: The base URL for PowerDNS API. Require `api=yes` and `api-readonly=no` in file `/etc/powerdns/pdns.conf`
  - axfr-time: The time in seconds to wait for AXFR in slaves. Can be set to 0 if there is only one authoritative server for the zone.
+
+The following two keys are optional and added in case a (nginx) reverse proxy is used to secure access to the api:
+ - http-auth (optional): A list of two strings containing the Username and Password for a http-basic-authentication
+ - verify-cert (optional): defines whether the SSL-certificate provided by the reverse proxy shall be verified. Possible options are True/False or a string containing the path to a local certificate which can be used to verify the one provided by the proxy.
 
 Usage
 -----

--- a/certbot-pdns.json
+++ b/certbot-pdns.json
@@ -1,5 +1,8 @@
 {
+  "http-auth-user": "user",
+  "http-auth-pass": "change_it",
   "api-key": "change_it",
+  "api-pass": "change_it_too",
   "base-url": "http://127.0.0.1:34022/api/v1",
   "axfr-time": 5
 }

--- a/certbot-pdns.json
+++ b/certbot-pdns.json
@@ -1,8 +1,7 @@
 {
-  "http-auth-user": "user",
-  "http-auth-pass": "change_it",
   "api-key": "change_it",
-  "api-pass": "change_it_too",
   "base-url": "http://127.0.0.1:34022/api/v1",
-  "axfr-time": 5
+  "axfr-time": 5,
+  "http-auth": ["user", "secret_pass"],
+  "verify-cert": "False"
 }

--- a/certbot_pdns/PdnsApiAuthenticator.py
+++ b/certbot_pdns/PdnsApiAuthenticator.py
@@ -61,10 +61,12 @@ class PdnsApiAuthenticator:
             config = json.load(f)
         self.api.set_api_key(config["api-key"])
         self.api.set_base_url(config["base-url"])
-        self.api.set_api_pass(config["api-pass"])
-        self.api.set_http_auth_user(config["http-auth-user"])
-        self.api.set_http_auth_pass(config["http-auth-pass"])
         self.axfr_time = config["axfr-time"]
+        # check if additional parameters are set before trying to assign them to ensure backwards compatibility
+        if "verify-cert" in config:
+            self.api.set_verify_cert(config["verify-cert"])
+        if "http-auth" in config:
+            self.api.set_http_auth(config["http-auth"])
         self.zones = self.api.list_zones()
         # print(self.zones)
         # raw_input('Press <ENTER> to continue')

--- a/certbot_pdns/PdnsApiAuthenticator.py
+++ b/certbot_pdns/PdnsApiAuthenticator.py
@@ -60,7 +60,7 @@ class PdnsApiAuthenticator:
         self.api.set_base_url(config["base-url"])
         self.api.set_api_pass(config["api-pass"])
         self.api.set_http_auth_user(config["http-auth-user"])
-        self.api.set_http_auth_pass(config["http-auth-pas"])
+        self.api.set_http_auth_pass(config["http-auth-pass"])
         self.axfr_time = config["axfr-time"]
         self.zones = self.api.list_zones()
         # print(self.zones)

--- a/certbot_pdns/PdnsApiAuthenticator.py
+++ b/certbot_pdns/PdnsApiAuthenticator.py
@@ -58,6 +58,9 @@ class PdnsApiAuthenticator:
             config = json.load(f)
         self.api.set_api_key(config["api-key"])
         self.api.set_base_url(config["base-url"])
+        self.api.set_api_pass(config["api-pass"])
+        self.api.set_http_auth_user(config["http-auth-user"])
+        self.api.set_http_auth_pass(config["http-auth-pas"])
         self.axfr_time = config["axfr-time"]
         self.zones = self.api.list_zones()
         # print(self.zones)

--- a/certbot_pdns/PdnsApiAuthenticator.py
+++ b/certbot_pdns/PdnsApiAuthenticator.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 import json
 
 import logging

--- a/certbot_pdns/__init__.py
+++ b/certbot_pdns/__init__.py
@@ -1,1 +1,4 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 """Let's Encrypt PDNS plugin"""

--- a/certbot_pdns/authenticator.py
+++ b/certbot_pdns/authenticator.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 """DNS plugin."""
 import collections
 import logging

--- a/certbot_pdns/pdnsapi.py
+++ b/certbot_pdns/pdnsapi.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 import json
 
 import requests

--- a/certbot_pdns/pdnsapi.py
+++ b/certbot_pdns/pdnsapi.py
@@ -26,9 +26,9 @@ class PdnsApi:
         elif isinstance(verify_cert, str):          # alternative: path to local cert is given as string
             self.verify_cert = verify_cert          # see requests-documentation for more info
         
-    def set_http_auth(self, http_auth):             # credentials should be given as list containing two elements
-        if len(http_auth == 2):                     # first: username, second: password for http-basic auth
-            self.http_auth = (str(http_auth[0]), str(http_auth[1]))
+    def set_http_auth(self, http_auth):             # credentials should be given as list containing two string-elements
+        if len(http_auth) == 2:                     # first: username, second: password for http-basic auth
+            self.http_auth = (str(http_auth[0]), str(http_auth[1]))     # ensure right format of credentials
         
     def _query(self, uri, method, kwargs=None):
         headers = {

--- a/certbot_pdns/pdnsapi.py
+++ b/certbot_pdns/pdnsapi.py
@@ -7,11 +7,10 @@ import requests
 
 
 class PdnsApi:
-    http_auth_user = None
-    http_auth_pass = None
     api_key = None
-    api_pass = None
     base_url = None
+    http_auth = None                                # Standard-value of requests-library will be used
+    verify_cert = None                              # Standard-value of requests-library will be used
 
     def set_api_key(self, api_key):
         self.api_key = api_key
@@ -19,14 +18,17 @@ class PdnsApi:
     def set_base_url(self, base_url):
         self.base_url = base_url
 
-    def set_api_pass(self, api_pass):
-        self.api_pass = api_pass
+    def set_verify_cert(self, verify_cert):
+        if verify_cert in ("True", "true"):         # convert from string to real bool
+            self.verify_cert = True
+        elif verify_cert in ("False", "false"):     # convert from string to real bool
+            self.verify_cert = False
+        elif isinstance(verify_cert, str):          # alternative: path to local cert is given as string
+            self.verify_cert = verify_cert          # see requests-documentation for more info
         
-    def set_http_auth_user(self, http_auth_user):
-        self.http_auth_user = http_auth_user
-        
-    def set_http_auth_pass(self, http_auth_pass):
-        self.http_auth_pass = http_auth_pass
+    def set_http_auth(self, http_auth):             # credentials should be given as list containing two elements
+        if len(http_auth == 2):                     # first: username, second: password for http-basic auth
+            self.http_auth = http_auth
         
     def _query(self, uri, method, kwargs=None):
         headers = {
@@ -38,15 +40,20 @@ class PdnsApi:
         data = json.dumps(kwargs)
 
         if method == "GET":
-            request = requests.get(self.base_url + uri, headers=headers, auth=(self.http_auth_user, self.http_auth_pass))
+            request = requests.get(self.base_url + uri, headers=headers,
+                                   auth=self.http_auth, verify=self.verify_cert)
         elif method == "POST":
-            request = requests.post(self.base_url + uri, headers=headers, auth=(self.http_auth_user, self.http_auth_pass), data=data)
+            request = requests.post(self.base_url + uri, headers=headers, data=data,
+                                    auth=self.http_auth, verify=self.verify_cert)
         elif method == "PUT":
-            request = requests.put(self.base_url + uri, headers=headers, auth=(self.http_auth_user, self.http_auth_pass), data=data)
+            request = requests.put(self.base_url + uri, headers=headers, data=data,
+                                   auth=self.http_auth, verify=self.verify_cert)
         elif method == "PATCH":
-            request = requests.patch(self.base_url + uri, headers=headers, auth=(self.http_auth_user, self.http_auth_pass), data=data)
+            request = requests.patch(self.base_url + uri, headers=headers, data=data,
+                                     auth=self.http_auth, verify=self.verify_cert)
         elif method == "DELETE":
-            request = requests.delete(self.base_url + uri, headers=headers, auth=(self.http_auth_user, self.http_auth_pass))
+            request = requests.delete(self.base_url + uri, headers=headers,
+                                      auth=self.http_auth, verify=self.verify_cert)
         else:
             raise ValueError("Invalid method '%s'" % method)
 

--- a/certbot_pdns/pdnsapi.py
+++ b/certbot_pdns/pdnsapi.py
@@ -4,7 +4,10 @@ import requests
 
 
 class PdnsApi:
+    http_auth_user = None
+    http_auth_pass = None
     api_key = None
+    api_pass = None
     base_url = None
 
     def set_api_key(self, api_key):
@@ -13,6 +16,15 @@ class PdnsApi:
     def set_base_url(self, base_url):
         self.base_url = base_url
 
+    def set_api_pass(self, api_pass):
+        self.api_pass = api_pass
+        
+    def set_http_auth_user(self, http_auth_user):
+        self.http_auth_user = http_auth_user
+        
+    def set_http_auth_pass(self, http_auth_pass):
+        self.http_auth_pass = http_auth_pass
+        
     def _query(self, uri, method, kwargs=None):
         headers = {
             'X-API-Key': self.api_key,
@@ -23,15 +35,15 @@ class PdnsApi:
         data = json.dumps(kwargs)
 
         if method == "GET":
-            request = requests.get(self.base_url + uri, headers=headers)
+            request = requests.get(self.base_url + uri, headers=headers, auth=(self.http_auth_user, self.http_auth_pass))
         elif method == "POST":
-            request = requests.post(self.base_url + uri, headers=headers, data=data)
+            request = requests.post(self.base_url + uri, headers=headers, auth=(self.http_auth_user, self.http_auth_pass), data=data)
         elif method == "PUT":
-            request = requests.put(self.base_url + uri, headers=headers, data=data)
+            request = requests.put(self.base_url + uri, headers=headers, auth=(self.http_auth_user, self.http_auth_pass), data=data)
         elif method == "PATCH":
-            request = requests.patch(self.base_url + uri, headers=headers, data=data)
+            request = requests.patch(self.base_url + uri, headers=headers, auth=(self.http_auth_user, self.http_auth_pass), data=data)
         elif method == "DELETE":
-            request = requests.delete(self.base_url + uri, headers=headers)
+            request = requests.delete(self.base_url + uri, headers=headers, auth=(self.http_auth_user, self.http_auth_pass))
         else:
             raise ValueError("Invalid method '%s'" % method)
 

--- a/certbot_pdns/pdnsapi.py
+++ b/certbot_pdns/pdnsapi.py
@@ -28,7 +28,7 @@ class PdnsApi:
         
     def set_http_auth(self, http_auth):             # credentials should be given as list containing two elements
         if len(http_auth == 2):                     # first: username, second: password for http-basic auth
-            self.http_auth = http_auth
+            self.http_auth = (str(http_auth[0]), str(http_auth[1]))
         
     def _query(self, uri, method, kwargs=None):
         headers = {

--- a/certbot_pdns/pdnsapi.py
+++ b/certbot_pdns/pdnsapi.py
@@ -19,9 +19,9 @@ class PdnsApi:
         self.base_url = base_url
 
     def set_verify_cert(self, verify_cert):
-        if verify_cert in ("True", "true"):         # convert from string to real bool
+        if verify_cert in ("True", "true", True):         # convert from string to real bool if needed
             self.verify_cert = True
-        elif verify_cert in ("False", "false"):     # convert from string to real bool
+        elif verify_cert in ("False", "false", False):    # convert from string to real bool if needed
             self.verify_cert = False
         elif isinstance(verify_cert, str):          # alternative: path to local cert is given as string
             self.verify_cert = verify_cert          # see requests-documentation for more info


### PR DESCRIPTION
In my scenario the certbot-client is not on the same host as the PDNS-Server. To secure the PDNS-API it is served via a nginx reverse-proxy protected via http auth. As the used request-library is already able to handle http-auth and https I modified the plugin to make use of it.

I tried to keep everything backwards-compatible and tested the plugin both with the additional settings as well as without.

Maybe others will find it useful as well.