### PR TITLE
etc not relative

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ necessary validation resources to appropriate records in a PowerDNS server.""",
     package_data={
     },
 
-    data_files=[('etc/letsencrypt', ['certbot-pdns.json'])],
+    data_files=[('/etc/letsencrypt', ['certbot-pdns.json'])],
 
     entry_points={
         'certbot.plugins': [


### PR DESCRIPTION
With etc instead of /etc, certbot-pdns.json is incorrectly installed to /usr/etc/letsencrypt (on Gentoo)